### PR TITLE
Count named subtrees in Phase 2 validator limits (closes #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unknown and stale inputs are not converted to booleans.
 - Replay cannot create physical outputs.
 - Intent-tree safe terminals are an explicit `safeTerminal` mark in last-child fallback/recovery position. Name substrings such as `park` / `safe` / `hold` are not treated as safety proofs. Trees that relied on `ParkSafely` by name must call `IntentNode.safeTerminal(...)` (SNAPSHOT break; no release yet).
+- `PlanValidator` applies `maxTreeNodes` / `maxTreeDepth` and parallel exclusive-resource checks to reachable expanded subtrees. Unreachable named subtrees remain warnings and are not counted toward live limits (SNAPSHOT stricter validation).

--- a/docs/intent-trees.md
+++ b/docs/intent-trees.md
@@ -45,7 +45,7 @@ IntentTree.named("SimpleAutonomous").fallback(
 ## This scaffold
 
 - Trees can be built with the student API (`IntentTree.named(...).fallback(...)`).
-- `PlanValidator` rejects missing timeouts, unbounded/missing retry policy, missing safe terminals, cyclic subtrees, exclusive resource conflicts in parallel, empty control nodes, and oversize trees.
+- `PlanValidator` rejects missing timeouts, unbounded/missing retry policy, missing safe terminals, cyclic subtrees, exclusive resource conflicts in parallel, empty control nodes, and oversize trees. Node and depth limits, and parallel exclusive-resource checks, apply to the reachable expanded tree (named subtree targets followed from the root). Unreachable named subtrees are warnings and are not counted toward live limits.
 - `SimulatedTreeWalker` ticks trees against in-memory leaves for unit tests.
 - **No** Pedro/MIMIC adapter is invoked. **No** execute mode can produce physical output.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -7,13 +7,14 @@ HELM must fit FTC Android / Control Hub constraints.
 | Decision frequency | Once per snapshot / caller tick | Caller-controlled; HELM does not spin |
 | Decision-time budget | 5 ms (`HelmConfig.decisionTimeBudget`) | Mark evaluation **incomplete**; do not return a partial selection as complete |
 | Snapshot max age | 100 ms | `STALE_INPUT` |
-| Max tree depth | 16 | Validation error |
-| Max tree nodes | 64 | Validation error |
+| Max tree depth | 16 | Validation error after reachable subtree expansion |
+| Max tree nodes | 64 | Validation error after reachable subtree expansion |
 | Max candidates | 8 | Recommendation refused |
 | History capacity | 64 events | Drop oldest |
 
 Rules:
 
+- `maxTreeNodes` / `maxTreeDepth` apply after reachable named-subtree expansion. Unreachable named subtrees are warnings and are not counted toward those limits.
 - No blocking in the OpMode loop
 - No file I/O or network on the decision path
 - No evaluating every possible future task continuously (selection not enabled)

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,8 +1,8 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source of findings: [initial deep audit](audits/initial-deep-audit.md) (commit `cb214b2e080ccc34d5536b5c0434a0c7cb143bd5`, 2026-08-17).
+Maintained by the repository orchestrator. Source of findings: [initial deep audit](audits/initial-deep-audit.md) (audited `cb214b2`; `main` after #27 is `f84b311`).
 
-**Automatic merge:** false. **Max active implementation subagents:** 1. **Identity:** TA-C-GHill.
+**Automatic merge:** human-authorized for this continue cycle after PR #27. **Max active implementation subagents:** 1. **Identity:** TA-C-GHill.
 
 Priority model (highest first): safety blockers → correctness blockers → CI/build failures → issues that unblock many others → architectural seams → tests for upcoming work → small user-facing slices → measured performance → docs/usability → optional advanced capabilities → cosmetic cleanup.
 
@@ -10,39 +10,38 @@ Priority model (highest first): safety blockers → correctness blockers → CI/
 
 | Field | Value |
 |-------|--------|
-| Open implementation PR to `main` | Draft [#16](https://github.com/The-Allsparks/HELM/pull/16) |
-| Selected issue | [#17](https://github.com/The-Allsparks/HELM/issues/17) explicit safe-terminal marking |
-| Why selected | Highest-priority **ready** safety/correctness defect; no hardware; unblocks honest Phase 2 |
-| Subagent | Single-use review/implement for #17 |
-| Merge status | Not authorized without human approval (`AUTOMATIC_MERGE=false`) |
+| `main` | `f84b311` — [PR #27](https://github.com/The-Allsparks/HELM/pull/27) merged; #17 closed |
+| Selected issue | [#18](https://github.com/The-Allsparks/HELM/issues/18) subtree-aware validator limits |
+| Why selected | Highest remaining HIGH correctness finding; unblocks #20 |
+| Branch | `fix/issue-18-subtree-limits` |
+| Hardware | None |
 
 ## Ledger
 
-| Issue | Priority | Readiness | Dependencies | Status | Assigned subagent | Branch | Pull request | CI | Merge | Blocker | Next action |
-|-------|----------|-----------|--------------|--------|-------------------|--------|--------------|----|-------|---------|-------------|
-| [#17](https://github.com/The-Allsparks/HELM/issues/17) explicit safe terminal | 1 | Ready | Scaffold in #16 | Selected | pending | `fix/issue-17-explicit-safe-terminal` | stacked on #16 stream | — | — | None | Review scope; implement smallest slice |
-| [#18](https://github.com/The-Allsparks/HELM/issues/18) subtree limits | 2 | Ready after #17 preferred | #8 / #17 fixtures | Pending | — | — | — | — | — | Prefer #17 first | Wait |
-| [#19](https://github.com/The-Allsparks/HELM/issues/19) skipped validation not valid | 3 | Ready | Scaffold | Pending | — | — | — | — | — | One issue at a time | After #17 |
-| [#21](https://github.com/The-Allsparks/HELM/issues/21) branch protection | 4 | Blocked | Human org settings | Blocked | — | n/a | n/a | n/a | n/a | Maintainer policy | Human enablement |
-| [#22](https://github.com/The-Allsparks/HELM/issues/22) Dependabot majors | 5 | Ready (analysis) | None | Do not merge #1–#4 | — | dependabot/* | #1–#4 | — | forbidden until analysis | Compatibility | Comment/close majors |
-| [#23](https://github.com/The-Allsparks/HELM/issues/23) README completion | 6 | Ready | None | Pending | — | — | — | — | — | None | After validator honesty |
-| [#20](https://github.com/The-Allsparks/HELM/issues/20) walker subtrees | 7 | Blocked | #18 | Blocked | — | — | — | — | — | #18 | Wait |
-| [#24](https://github.com/The-Allsparks/HELM/issues/24) future timestamps | 8 | Ready | None | Pending | — | — | — | — | — | None | Later |
-| [#26](https://github.com/The-Allsparks/HELM/issues/26) examples path | 9 | Ready | Scaffold | Pending | — | — | — | — | — | None | Later |
-| [#25](https://github.com/The-Allsparks/HELM/issues/25) desktop characterization | 10 | Ready (desktop) | None | Pending | — | — | — | — | — | Do not claim Control Hub | Later |
-| [#9](https://github.com/The-Allsparks/HELM/issues/9)–[#15](https://github.com/The-Allsparks/HELM/issues/15) Phase 3+ | 13+ | Blocked | Readiness gates | Blocked | — | — | — | — | — | `docs/readiness-gates.md` | Do not implement |
-| [#6](https://github.com/The-Allsparks/HELM/issues/6) [#7](https://github.com/The-Allsparks/HELM/issues/7) [#8](https://github.com/The-Allsparks/HELM/issues/8) | Delivery | #8 incomplete until #17–#19 | None | Open; #8 is epic | — | `feature/phase-0-passive-scaffold` | #16 | success | waiting human | #17–#19 | Fix HIGH findings before treating #8 complete |
+| Issue | Priority | Readiness | Dependencies | Status | Branch | Pull request | CI | Merge | Blocker | Next action |
+|-------|----------|-----------|--------------|--------|--------|--------------|----|-------|---------|-------------|
+| [#17](https://github.com/The-Allsparks/HELM/issues/17) explicit safe terminal | 1 | Done | Scaffold | Closed | `fix/issue-17-explicit-safe-terminal` | [#27](https://github.com/The-Allsparks/HELM/pull/27) | success | merged | None | Done |
+| [#18](https://github.com/The-Allsparks/HELM/issues/18) subtree limits | 2 | Ready | #17 | In progress | `fix/issue-18-subtree-limits` | pending | — | — | None | Open PR |
+| [#19](https://github.com/The-Allsparks/HELM/issues/19) skipped validation not valid | 3 | Ready | Scaffold | Pending | — | — | — | — | One issue at a time | After #18 |
+| [#21](https://github.com/The-Allsparks/HELM/issues/21) branch protection | 4 | Blocked | Human org settings | Blocked | n/a | n/a | n/a | n/a | Maintainer policy | Human enablement |
+| [#22](https://github.com/The-Allsparks/HELM/issues/22) Dependabot majors | 5 | Ready (analysis) | None | Do not merge #4, #28–#30 | dependabot/* | #4, #28–#30 | — | forbidden until analysis | Compatibility | Analysis comments |
+| [#23](https://github.com/The-Allsparks/HELM/issues/23) README completion | 6 | Ready | None | Pending | — | — | — | — | None | After #19 |
+| [#20](https://github.com/The-Allsparks/HELM/issues/20) walker subtrees | 7 | Blocked | #18 | Blocked until #18 merges | — | — | — | — | #18 | Wait |
+| [#24](https://github.com/The-Allsparks/HELM/issues/24) future timestamps | 8 | Ready | None | Pending | — | — | — | — | None | Later |
+| [#26](https://github.com/The-Allsparks/HELM/issues/26) examples path | 9 | Ready | Scaffold | Pending | — | — | — | — | None | Later |
+| [#25](https://github.com/The-Allsparks/HELM/issues/25) desktop characterization | 10 | Ready (desktop) | None | Pending | — | — | — | — | Do not claim Control Hub | Later |
+| [#9](https://github.com/The-Allsparks/HELM/issues/9)–[#15](https://github.com/The-Allsparks/HELM/issues/15) Phase 3+ | 13+ | Blocked | Readiness gates | Blocked | — | — | — | — | `docs/readiness-gates.md` | Do not implement |
+| [#6](https://github.com/The-Allsparks/HELM/issues/6) [#7](https://github.com/The-Allsparks/HELM/issues/7) | Delivery | Done | None | Closed via #27 | — | #27 | success | merged | None | Done |
+| [#8](https://github.com/The-Allsparks/HELM/issues/8) Phase 2 epic | Delivery | Incomplete until #18–#19 | #17 done | Open | — | — | — | — | #18 #19 | Continue children |
 
 ## Work completed this cycle
 
-- Deep audit: `docs/audits/initial-deep-audit.md`.
-- Labels: `severity:*`, `type:*`, `epic`, `ready`.
-- Milestones: Passive-core correctness (#11), Repository health (#12).
-- Issues #17–#26 filed from audit findings.
+- PR #27 merged to `main`; post-merge CI success.
+- #17 closed; Phase 0 (#6) and Phase 1 (#7) closed.
+- #18 implemented on `fix/issue-18-subtree-limits`.
 
 ## Required human decisions
 
-1. Merge authorization for PR #16 after HIGH Phase 2 defects are addressed or explicitly deferred.
-2. Enable branch protection and required CI on `main` (#21).
-3. Whether to add an FTC SDK / Android compile job (audit F-TEST-004; not filed as ready).
-4. Do not merge Dependabot PRs #1–#4 without the analysis in #22.
+1. Enable branch protection and required CI on `main` (#21).
+2. Whether to add an FTC SDK / Android compile job (audit F-TEST-004).
+3. Do not merge Dependabot PRs #4, #28–#30 without the analysis in #22.

--- a/src/main/java/org/allsparks/helm/validate/PlanValidator.java
+++ b/src/main/java/org/allsparks/helm/validate/PlanValidator.java
@@ -49,16 +49,18 @@ public final class PlanValidator {
 
     public ValidationReport validate(IntentTree tree) {
         List<ValidationFinding> findings = new ArrayList<>();
-        if (tree.nodeCount() > config.maxTreeNodes()) {
+        Set<String> reachable = new HashSet<>();
+        Expansion expansion = new Expansion();
+        walk(tree.root(), tree.name(), tree.subtrees(), new ArrayDeque<>(), reachable, findings,
+                expansion, 1);
+        if (expansion.nodeCount > config.maxTreeNodes()) {
             findings.add(error(FailureReason.INVALID_PLAN, tree.name(),
                     "Tree exceeds max nodes " + config.maxTreeNodes()));
         }
-        if (tree.depth() > config.maxTreeDepth()) {
+        if (expansion.maxDepth > config.maxTreeDepth()) {
             findings.add(error(FailureReason.INVALID_PLAN, tree.name(),
                     "Tree exceeds max depth " + config.maxTreeDepth()));
         }
-        Set<String> reachable = new HashSet<>();
-        walk(tree.root(), tree.name(), tree.subtrees(), new ArrayDeque<>(), reachable, findings);
         for (Map.Entry<String, IntentNode> entry : tree.subtrees().entrySet()) {
             if (!reachable.contains(entry.getKey())) {
                 findings.add(warning(FailureReason.INVALID_PLAN, entry.getKey(),
@@ -78,7 +80,13 @@ public final class PlanValidator {
             Map<String, IntentNode> subtrees,
             ArrayDeque<String> subtreeStack,
             Set<String> reachable,
-            List<ValidationFinding> findings) {
+            List<ValidationFinding> findings,
+            Expansion expansion,
+            int depth) {
+        expansion.nodeCount++;
+        if (depth > expansion.maxDepth) {
+            expansion.maxDepth = depth;
+        }
         String here = path + "/" + node.name();
         if (node.kind() == IntentNodeKind.ACTION && node.timeout().isEmpty()) {
             findings.add(error(FailureReason.MISSING_TIMEOUT, here,
@@ -99,7 +107,7 @@ public final class PlanValidator {
             findings.add(error(FailureReason.INVALID_PLAN, here,
                     node.kind() + " node '" + node.name() + "' has no children"));
         }
-        detectResourceConflicts(node, here, findings);
+        detectResourceConflicts(node, here, subtrees, subtreeStack, findings);
         if (node.kind() == IntentNodeKind.SUBTREE) {
             String subtreeName = node.subtreeName().orElse(node.name());
             reachable.add(subtreeName);
@@ -115,22 +123,27 @@ public final class PlanValidator {
                 return;
             }
             subtreeStack.addLast(subtreeName);
-            walk(target, here, subtrees, subtreeStack, reachable, findings);
+            walk(target, here, subtrees, subtreeStack, reachable, findings, expansion, depth + 1);
             subtreeStack.removeLast();
             return;
         }
         for (IntentNode child : node.children()) {
-            walk(child, here, subtrees, subtreeStack, reachable, findings);
+            walk(child, here, subtrees, subtreeStack, reachable, findings, expansion, depth + 1);
         }
     }
 
-    private void detectResourceConflicts(IntentNode node, String path, List<ValidationFinding> findings) {
+    private void detectResourceConflicts(
+            IntentNode node,
+            String path,
+            Map<String, IntentNode> subtrees,
+            ArrayDeque<String> subtreeStack,
+            List<ValidationFinding> findings) {
         if (node.kind() != IntentNodeKind.PARALLEL) {
             return;
         }
         Set<Resource> exclusive = new LinkedHashSet<>();
         for (IntentNode child : node.children()) {
-            for (Resource resource : collectExclusive(child)) {
+            for (Resource resource : collectExclusive(child, subtrees, subtreeStack)) {
                 if (!exclusive.add(resource)) {
                     findings.add(error(FailureReason.RESOURCE_CONFLICT, path,
                             "Parallel node claims exclusive resource '" + resource.name()
@@ -140,15 +153,32 @@ public final class PlanValidator {
         }
     }
 
-    private List<Resource> collectExclusive(IntentNode node) {
+    private List<Resource> collectExclusive(
+            IntentNode node,
+            Map<String, IntentNode> subtrees,
+            ArrayDeque<String> subtreeStack) {
         List<Resource> found = new ArrayList<>();
         for (Resource resource : node.resources()) {
             if (resource.exclusive()) {
                 found.add(resource);
             }
         }
+        if (node.kind() == IntentNodeKind.SUBTREE) {
+            String subtreeName = node.subtreeName().orElse(node.name());
+            if (subtreeStack.contains(subtreeName)) {
+                return found;
+            }
+            IntentNode target = subtrees.get(subtreeName);
+            if (target == null) {
+                return found;
+            }
+            subtreeStack.addLast(subtreeName);
+            found.addAll(collectExclusive(target, subtrees, subtreeStack));
+            subtreeStack.removeLast();
+            return found;
+        }
         for (IntentNode child : node.children()) {
-            found.addAll(collectExclusive(child));
+            found.addAll(collectExclusive(child, subtrees, subtreeStack));
         }
         return found;
     }
@@ -186,5 +216,10 @@ public final class PlanValidator {
 
     private static ValidationFinding warning(FailureReason reason, String path, String message) {
         return new ValidationFinding(ValidationSeverity.WARNING, reason, path, message);
+    }
+
+    private static final class Expansion {
+        private int nodeCount;
+        private int maxDepth;
     }
 }

--- a/src/test/java/org/allsparks/helm/validate/SubtreeLimitValidationTest.java
+++ b/src/test/java/org/allsparks/helm/validate/SubtreeLimitValidationTest.java
@@ -1,0 +1,129 @@
+package org.allsparks.helm.validate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.allsparks.helm.HelmConfig;
+import org.allsparks.helm.HelmFeatureFlags;
+import org.allsparks.helm.HelmMode;
+import org.allsparks.helm.clock.ManualClock;
+import org.allsparks.helm.intent.IntentNode;
+import org.allsparks.helm.intent.IntentNodeKind;
+import org.allsparks.helm.intent.IntentTree;
+import org.allsparks.helm.resource.Resource;
+import org.allsparks.helm.task.TimeoutPolicy;
+import org.junit.jupiter.api.Test;
+
+class SubtreeLimitValidationTest {
+    private final ManualClock clock = new ManualClock();
+    private final PlanValidator defaultValidator = new PlanValidator(HelmConfig.forTests(clock));
+
+    @Test
+    void expandedNodeCountExceedingMaxTreeNodesIsError() {
+        PlanValidator validator = validatorWithLimits(1, 16);
+        IntentTree tree = IntentTree.named("oversize-nodes")
+                .subtree("payload", timed("ScorePreload"))
+                .root(IntentNode.subtree("payload"));
+        ValidationReport report = validator.validate(tree);
+        assertFalse(report.isValid());
+        assertTrue(report.explanation().contains("max nodes"));
+    }
+
+    @Test
+    void expandedDepthExceedingMaxTreeDepthIsError() {
+        PlanValidator validator = validatorWithLimits(64, 1);
+        IntentTree tree = IntentTree.named("oversize-depth")
+                .subtree("payload", timed("ScorePreload"))
+                .root(IntentNode.subtree("payload"));
+        ValidationReport report = validator.validate(tree);
+        assertFalse(report.isValid());
+        assertTrue(report.explanation().contains("max depth"));
+    }
+
+    @Test
+    void parallelExclusiveDrivetrainInsideNamedSubtreeIsError() {
+        IntentNode left = IntentNode.builder("left", IntentNodeKind.ACTION)
+                .timeout(TimeoutPolicy.ofSeconds(2))
+                .resource(Resource.DRIVETRAIN)
+                .build();
+        IntentNode nestedDrive = IntentNode.builder("nestedDrive", IntentNodeKind.ACTION)
+                .timeout(TimeoutPolicy.ofSeconds(2))
+                .resource(Resource.DRIVETRAIN)
+                .build();
+        IntentTree tree = IntentTree.named("conflict")
+                .subtree("inside", nestedDrive)
+                .root(IntentNode.fallback(
+                        IntentNode.parallel("both", left, IntentNode.subtree("inside")),
+                        timeoutWrappedSafeTerminal("ParkSafely")));
+        ValidationReport report = defaultValidator.validate(tree);
+        assertFalse(report.isValid());
+        assertTrue(report.explanation().contains("exclusive resource"));
+    }
+
+    @Test
+    void cyclicSubtreeIsStillReported() {
+        IntentTree cyclic = IntentTree.named("cycle")
+                .subtree("A", IntentNode.subtree("B"))
+                .subtree("B", IntentNode.subtree("A"))
+                .root(IntentNode.subtree("A"));
+        ValidationReport report = defaultValidator.validate(cyclic);
+        assertFalse(report.isValid());
+        assertTrue(report.explanation().toLowerCase().contains("cyclic"));
+    }
+
+    @Test
+    void unreachableSubtreeIsWarningAndDoesNotCountTowardLimits() {
+        PlanValidator validator = validatorWithLimits(6, 8);
+        IntentTree tree = IntentTree.named("orphan")
+                .subtree("unused", IntentNode.sequence(
+                        timed("a"), timed("b"), timed("c"), timed("d"), timed("e"), timed("f")))
+                .root(IntentNode.fallback(
+                        timed("ScorePreload"),
+                        timeoutWrappedSafeTerminal("ParkSafely")));
+        ValidationReport report = validator.validate(tree);
+        assertTrue(report.isValid());
+        assertTrue(report.errors().isEmpty());
+        assertTrue(report.findings().stream().anyMatch(finding ->
+                finding.severity() == ValidationSeverity.WARNING
+                        && finding.message().contains("not reachable")));
+    }
+
+    @Test
+    void smallExpandedTreeUnderLimitsCanBeValid() {
+        IntentTree tree = IntentTree.named("ok")
+                .subtree("score", timed("ScorePreload"))
+                .root(IntentNode.fallback(
+                        IntentNode.subtree("score"),
+                        timeoutWrappedSafeTerminal("ParkSafely")));
+        assertTrue(defaultValidator.validate(tree).isValid());
+    }
+
+    private PlanValidator validatorWithLimits(int maxTreeNodes, int maxTreeDepth) {
+        return new PlanValidator(HelmConfig.builder()
+                .mode(HelmMode.VALIDATE)
+                .flags(HelmFeatureFlags.validate())
+                .clock(clock)
+                .maxTreeNodes(maxTreeNodes)
+                .maxTreeDepth(maxTreeDepth)
+                .build());
+    }
+
+    private static IntentNode timed(String name) {
+        return IntentNode.builder(name, IntentNodeKind.ACTION)
+                .timeout(TimeoutPolicy.ofSeconds(2))
+                .build();
+    }
+
+    private static IntentNode timedSafeTerminal(String name) {
+        return IntentNode.builder(name, IntentNodeKind.ACTION)
+                .safeTerminal(true)
+                .timeout(TimeoutPolicy.ofSeconds(2))
+                .build();
+    }
+
+    private static IntentNode timeoutWrappedSafeTerminal(String name) {
+        return IntentNode.timeout("parkTimeout", Duration.ofSeconds(2), timedSafeTerminal(name));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 validation now applies node, depth, and parallel exclusive-resource limits to the reachable expanded intent tree, including named subtree targets.

## Problem

`PlanValidator` used `IntentTree.nodeCount()` and `depth()`, which walk only children. A one-node `SUBTREE` root could hide an oversized or resource-conflicting named subtree. Parallel exclusive-resource detection also skipped subtree maps.

## Solution

Count expanded nodes and depth during the existing `walk()`. Follow named subtrees for exclusive-resource collection with the same cycle guard. Unreachable named subtrees remain warnings and are not counted toward live limits.

## Scope

- `PlanValidator` expanded size/depth/resource checks
- Unit tests for oversize nodes, oversize depth, hidden drivetrain conflict, cycles, unreachable warnings, and a valid small expanded tree
- Docs and changelog

## Out of scope

- Simulated walker resolving named subtrees (#20)
- Skipped validation reporting valid (#19)
- Phase 3+ execution or hardware
- Changing default `maxTreeNodes` / `maxTreeDepth` values

## Phase / maturity impact

- [ ] Documentation only
- [ ] Phase 0 vocabulary
- [ ] Phase 1 passive observation
- [x] Phase 2 offline validation
- [ ] Phase 3+ (requires explicit safety review and is not approved)
- [ ] Research / citations

## Architecture impact

`IntentTree.nodeCount()` / `depth()` remain unexpanded inspectable metrics. Validator budgets use reachable expansion.

## Safety impact

- [x] Does **not** enable hardware command or execute authority by default
- [x] Unknown/stale sensing fails safe
- [x] Replay cannot produce physical output
- [x] No secrets or private team data included
- Tightens static validation (SNAPSHOT). `AuthorityGate.allowsPhysicalOutput()` remains false.

## Compatibility impact

0.1.0-SNAPSHOT. Trees that previously passed by hiding structure in named subtrees will now fail.

## Tests

- [x] `./gradlew.bat check` passed locally (53 tests, 0 failures)
- [x] Unit tests added (`SubtreeLimitValidationTest`)
- [x] Hardware validation status: none

## Validation results

Command: `.\gradlew.bat check --no-daemon`

Result: BUILD SUCCESSFUL

Failure reason: none

Whether failure is introduced by this change: no

## Hardware validation

None. Desktop unit tests only.

## Documentation

`docs/intent-trees.md`, `docs/performance.md`, `CHANGELOG.md`, `docs/priority-ledger.md`

## Risks

Stricter validation. Intended.

## Rollback or disable strategy

Revert this PR. Phase 2 remains flag-gated. Default mode remains `OFF`.

## Known limitations

- Walker still does not resolve named subtrees (#20)
- Safe-terminal walk still does not enter named subtree maps
- No Control Hub measurement

## Related issue

Closes #18

Part of #8
