### PR TITLE
Skipped validation must not report a plan as valid (closes #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replay cannot create physical outputs.
 - Intent-tree safe terminals are an explicit `safeTerminal` mark in last-child fallback/recovery position. Name substrings such as `park` / `safe` / `hold` are not treated as safety proofs. Trees that relied on `ParkSafely` by name must call `IntentNode.safeTerminal(...)` (SNAPSHOT break; no release yet).
 - `PlanValidator` applies `maxTreeNodes` / `maxTreeDepth` and parallel exclusive-resource checks to reachable expanded subtrees. Unreachable named subtrees remain warnings and are not counted toward live limits (SNAPSHOT stricter validation).
+- Skipped validation reports `NOT_RUN` status; `ValidationReport.isValid()` is false unless validation actually ran and found no errors. Empty skipped reports are no longer treated as valid (SNAPSHOT behavioral break).

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,47 +1,39 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source of findings: [initial deep audit](audits/initial-deep-audit.md) (audited `cb214b2`; `main` after #27 is `f84b311`).
+Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `24241c4` after [#31](https://github.com/The-Allsparks/HELM/pull/31).
 
-**Automatic merge:** human-authorized for this continue cycle after PR #27. **Max active implementation subagents:** 1. **Identity:** TA-C-GHill.
-
-Priority model (highest first): safety blockers → correctness blockers → CI/build failures → issues that unblock many others → architectural seams → tests for upcoming work → small user-facing slices → measured performance → docs/usability → optional advanced capabilities → cosmetic cleanup.
+**Identity:** TA-C-GHill. **Max active subagents:** 1.
 
 ## Current stream
 
 | Field | Value |
 |-------|--------|
-| `main` | `f84b311` — [PR #27](https://github.com/The-Allsparks/HELM/pull/27) merged; #17 closed |
-| Selected issue | [#18](https://github.com/The-Allsparks/HELM/issues/18) subtree-aware validator limits |
-| Why selected | Highest remaining HIGH correctness finding; unblocks #20 |
-| Branch | `fix/issue-18-subtree-limits` |
-| Hardware | None |
+| Selected issue | [#19](https://github.com/The-Allsparks/HELM/issues/19) skipped validation honesty |
+| Branch | `fix/issue-19-skipped-validation-not-valid` |
+| Status | PR pending |
 
-## Ledger
+## Ledger (abbreviated)
 
-| Issue | Priority | Readiness | Dependencies | Status | Branch | Pull request | CI | Merge | Blocker | Next action |
-|-------|----------|-----------|--------------|--------|--------|--------------|----|-------|---------|-------------|
-| [#17](https://github.com/The-Allsparks/HELM/issues/17) explicit safe terminal | 1 | Done | Scaffold | Closed | `fix/issue-17-explicit-safe-terminal` | [#27](https://github.com/The-Allsparks/HELM/pull/27) | success | merged | None | Done |
-| [#18](https://github.com/The-Allsparks/HELM/issues/18) subtree limits | 2 | Ready | #17 | In progress | `fix/issue-18-subtree-limits` | pending | — | — | None | Open PR |
-| [#19](https://github.com/The-Allsparks/HELM/issues/19) skipped validation not valid | 3 | Ready | Scaffold | Pending | — | — | — | — | One issue at a time | After #18 |
-| [#21](https://github.com/The-Allsparks/HELM/issues/21) branch protection | 4 | Blocked | Human org settings | Blocked | n/a | n/a | n/a | n/a | Maintainer policy | Human enablement |
-| [#22](https://github.com/The-Allsparks/HELM/issues/22) Dependabot majors | 5 | Ready (analysis) | None | Do not merge #4, #28–#30 | dependabot/* | #4, #28–#30 | — | forbidden until analysis | Compatibility | Analysis comments |
-| [#23](https://github.com/The-Allsparks/HELM/issues/23) README completion | 6 | Ready | None | Pending | — | — | — | — | None | After #19 |
-| [#20](https://github.com/The-Allsparks/HELM/issues/20) walker subtrees | 7 | Blocked | #18 | Blocked until #18 merges | — | — | — | — | #18 | Wait |
-| [#24](https://github.com/The-Allsparks/HELM/issues/24) future timestamps | 8 | Ready | None | Pending | — | — | — | — | None | Later |
-| [#26](https://github.com/The-Allsparks/HELM/issues/26) examples path | 9 | Ready | Scaffold | Pending | — | — | — | — | None | Later |
-| [#25](https://github.com/The-Allsparks/HELM/issues/25) desktop characterization | 10 | Ready (desktop) | None | Pending | — | — | — | — | Do not claim Control Hub | Later |
-| [#9](https://github.com/The-Allsparks/HELM/issues/9)–[#15](https://github.com/The-Allsparks/HELM/issues/15) Phase 3+ | 13+ | Blocked | Readiness gates | Blocked | — | — | — | — | `docs/readiness-gates.md` | Do not implement |
-| [#6](https://github.com/The-Allsparks/HELM/issues/6) [#7](https://github.com/The-Allsparks/HELM/issues/7) | Delivery | Done | None | Closed via #27 | — | #27 | success | merged | None | Done |
-| [#8](https://github.com/The-Allsparks/HELM/issues/8) Phase 2 epic | Delivery | Incomplete until #18–#19 | #17 done | Open | — | — | — | — | #18 #19 | Continue children |
+| Issue | Status | PR |
+|-------|--------|-----|
+| #17 | Closed | [#27](https://github.com/The-Allsparks/HELM/pull/27) merged |
+| #18 | Closed | [#31](https://github.com/The-Allsparks/HELM/pull/31) merged |
+| #19 | In progress | pending |
+| #20 | Ready (unblocked) | — |
+| #6 #7 | Closed | via #27 |
+| #8 epic | Open | #17–#19 children; #20 optional for desktop parity |
+| #21 | Blocked | human branch protection |
+| #22 | Ready | do not merge Dependabot #4, #28–#30 |
+| #9–#15 | Blocked | readiness gates |
 
-## Work completed this cycle
+## Next after #19
 
-- PR #27 merged to `main`; post-merge CI success.
-- #17 closed; Phase 0 (#6) and Phase 1 (#7) closed.
-- #18 implemented on `fix/issue-18-subtree-limits`.
+1. [#20](https://github.com/The-Allsparks/HELM/issues/20) walker resolves named subtrees (desktop parity)
+2. [#23](https://github.com/The-Allsparks/HELM/issues/23) README completion (small docs)
+3. [#24](https://github.com/The-Allsparks/HELM/issues/24) future-dated snapshots
 
 ## Required human decisions
 
-1. Enable branch protection and required CI on `main` (#21).
-2. Whether to add an FTC SDK / Android compile job (audit F-TEST-004).
-3. Do not merge Dependabot PRs #4, #28–#30 without the analysis in #22.
+- Enable branch protection (#21)
+- Dependabot major-upgrade policy (#22)
+- FTC SDK compile job (audit F-TEST-004; not filed)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,7 @@
 | `UNKNOWN_CONDITION` | Fact missing from snapshot | Put the named condition in the snapshot; do not default it to false |
 | `STALE_INPUT` | Snapshot older than max age, or timestamps misaligned | Check clocks and alignment window |
 | `CAPABILITY_UNKNOWN` | BEACON/MIMIC did not report the capability | Leave the task blocked; do not invent AVAILABLE |
-| Validation empty and “valid” | Phase 2 flag off or mode OFF | Enable `HelmFeatureFlags.validate()` and `VALIDATE` |
+| `validate` returns not run / `isValid()` false with empty findings | Phase 2 flag off or mode OFF | Enable `HelmFeatureFlags.validate()` and set mode to `VALIDATE`; check `ValidationReport.status()` |
 | Tree invalid despite a `ParkSafely` name | Name is not a safety proof | Mark `IntentNode.safeTerminal(...)` and put it last on a root fallback/recovery (typically inside `IntentNode.timeout(...)`). Each ACTION still needs its own timeout. |
 | `observe` returns empty | Phase 1 off or mode OFF | Enable observe flags |
 | Recommend disabled | Phase 4 not implemented | Expected |

--- a/src/main/java/org/allsparks/helm/Helm.java
+++ b/src/main/java/org/allsparks/helm/Helm.java
@@ -143,7 +143,7 @@ public final class Helm {
         Objects.requireNonNull(task, "task");
         if (config.mode() == HelmMode.OFF || !config.flags().isPhase2Validate()
                 || !config.mode().allowsValidation()) {
-            return new ValidationReport(task.name(), List.of());
+            return ValidationReport.notRun(task.name(), validationSkipReason());
         }
         ValidationReport report = validator.validate(task);
         config.traceSink().record(new TraceEvent(
@@ -162,7 +162,7 @@ public final class Helm {
         Objects.requireNonNull(tree, "tree");
         if (config.mode() == HelmMode.OFF || !config.flags().isPhase2Validate()
                 || !config.mode().allowsValidation()) {
-            return new ValidationReport(tree.name(), List.of());
+            return ValidationReport.notRun(tree.name(), validationSkipReason());
         }
         ValidationReport report = validator.validate(tree);
         config.traceSink().record(new TraceEvent(
@@ -194,5 +194,15 @@ public final class Helm {
             evaluations.add(evaluate(task, snapshot));
         }
         return List.copyOf(evaluations);
+    }
+
+    private String validationSkipReason() {
+        if (config.mode() == HelmMode.OFF) {
+            return "HELM mode is OFF";
+        }
+        if (!config.flags().isPhase2Validate()) {
+            return "Phase 2 validation is not enabled";
+        }
+        return "Mode " + config.mode() + " does not allow validation";
     }
 }

--- a/src/main/java/org/allsparks/helm/validate/ValidationReport.java
+++ b/src/main/java/org/allsparks/helm/validate/ValidationReport.java
@@ -8,14 +8,35 @@ import java.util.stream.Collectors;
 
 /**
  * Result of offline plan validation. Invalid plans are not rewritten.
+ *
+ * <p>When validation is skipped because mode or flags disallow it, use
+ * {@link #notRun(String, String)}. {@link #isValid()} is {@code true} only when
+ * validation actually ran and found no errors.
  */
 public final class ValidationReport {
     private final String subject;
     private final List<ValidationFinding> findings;
+    private final ValidationStatus status;
+    private final String skipReason;
 
     public ValidationReport(String subject, List<ValidationFinding> findings) {
         this.subject = Objects.requireNonNull(subject, "subject");
         this.findings = Collections.unmodifiableList(List.copyOf(findings));
+        this.status = findings.stream().anyMatch(ValidationFinding::isError)
+                ? ValidationStatus.INVALID
+                : ValidationStatus.VALID;
+        this.skipReason = null;
+    }
+
+    private ValidationReport(String subject, ValidationStatus status, String skipReason) {
+        this.subject = Objects.requireNonNull(subject, "subject");
+        this.findings = List.of();
+        this.status = Objects.requireNonNull(status, "status");
+        this.skipReason = Objects.requireNonNull(skipReason, "skipReason");
+    }
+
+    public static ValidationReport notRun(String subject, String reason) {
+        return new ValidationReport(subject, ValidationStatus.NOT_RUN, reason);
     }
 
     public String subject() {
@@ -26,8 +47,16 @@ public final class ValidationReport {
         return findings;
     }
 
+    public ValidationStatus status() {
+        return status;
+    }
+
+    public boolean wasValidated() {
+        return status != ValidationStatus.NOT_RUN;
+    }
+
     public boolean isValid() {
-        return findings.stream().noneMatch(ValidationFinding::isError);
+        return status == ValidationStatus.VALID;
     }
 
     public List<ValidationFinding> errors() {
@@ -35,7 +64,10 @@ public final class ValidationReport {
     }
 
     public String explanation() {
-        if (isValid()) {
+        if (status == ValidationStatus.NOT_RUN) {
+            return "Plan '" + subject + "' was not validated: " + skipReason;
+        }
+        if (status == ValidationStatus.VALID) {
             return "Plan '" + subject + "' is valid";
         }
         StringBuilder text = new StringBuilder("Plan '").append(subject).append("' is not safe to run: ");

--- a/src/main/java/org/allsparks/helm/validate/ValidationStatus.java
+++ b/src/main/java/org/allsparks/helm/validate/ValidationStatus.java
@@ -1,0 +1,13 @@
+package org.allsparks.helm.validate;
+
+/**
+ * Whether offline plan validation ran and what it concluded.
+ */
+public enum ValidationStatus {
+    /** Validation was skipped (mode or flags). */
+    NOT_RUN,
+    /** Validation ran and found no errors. */
+    VALID,
+    /** Validation ran and found at least one error. */
+    INVALID
+}

--- a/src/test/java/org/allsparks/helm/validate/SkippedValidationTest.java
+++ b/src/test/java/org/allsparks/helm/validate/SkippedValidationTest.java
@@ -1,0 +1,96 @@
+package org.allsparks.helm.validate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.allsparks.helm.Helm;
+import org.allsparks.helm.HelmConfig;
+import org.allsparks.helm.HelmFeatureFlags;
+import org.allsparks.helm.HelmMode;
+import org.allsparks.helm.clock.ManualClock;
+import org.allsparks.helm.condition.Condition;
+import org.allsparks.helm.task.Task;
+import org.junit.jupiter.api.Test;
+
+class SkippedValidationTest {
+    private final ManualClock clock = new ManualClock();
+
+    @Test
+    void offModeDoesNotReportValidPlan() {
+        Helm helm = Helm.create();
+        Task task = Task.builder("ParkSafely")
+                .timeout(Duration.ofSeconds(3))
+                .fallback("HoldSafe")
+                .completion(Condition.snapshotFact("parked"))
+                .build();
+
+        ValidationReport report = helm.validate(task);
+
+        assertEquals(ValidationStatus.NOT_RUN, report.status());
+        assertFalse(report.wasValidated());
+        assertFalse(report.isValid());
+        assertTrue(report.findings().isEmpty());
+        assertTrue(report.explanation().contains("was not validated"));
+        assertFalse(report.explanation().contains("is valid"));
+    }
+
+    @Test
+    void validateModeWithoutPhase2FlagDoesNotReportValidPlan() {
+        Helm helm = Helm.create(HelmConfig.builder()
+                .mode(HelmMode.VALIDATE)
+                .clock(clock)
+                .build());
+        Task task = Task.builder("ParkSafely")
+                .timeout(Duration.ofSeconds(3))
+                .fallback("HoldSafe")
+                .completion(Condition.snapshotFact("parked"))
+                .build();
+
+        ValidationReport report = helm.validate(task);
+
+        assertEquals(ValidationStatus.NOT_RUN, report.status());
+        assertFalse(report.isValid());
+        assertTrue(report.explanation().contains("Phase 2 validation is not enabled"));
+        assertFalse(report.explanation().contains("is valid"));
+    }
+
+    @Test
+    void validateModeWithFlagsReportsValidForCompleteTask() {
+        Helm helm = Helm.create(HelmConfig.builder()
+                .mode(HelmMode.VALIDATE)
+                .flags(HelmFeatureFlags.validate())
+                .clock(clock)
+                .build());
+        Task task = Task.builder("ParkSafely")
+                .timeout(Duration.ofSeconds(3))
+                .fallback("HoldSafe")
+                .completion(Condition.snapshotFact("parked"))
+                .build();
+
+        ValidationReport report = helm.validate(task);
+
+        assertEquals(ValidationStatus.VALID, report.status());
+        assertTrue(report.wasValidated());
+        assertTrue(report.isValid());
+        assertTrue(report.explanation().contains("is valid"));
+    }
+
+    @Test
+    void observeModeDoesNotReportValidPlan() {
+        Helm helm = Helm.create(HelmConfig.builder()
+                .mode(HelmMode.OBSERVE)
+                .flags(HelmFeatureFlags.validate())
+                .clock(clock)
+                .build());
+        Task task = Task.builder("ParkSafely").build();
+
+        ValidationReport report = helm.validate(task);
+
+        assertEquals(ValidationStatus.NOT_RUN, report.status());
+        assertFalse(report.isValid());
+        assertTrue(report.explanation().contains("does not allow validation"));
+    }
+}


### PR DESCRIPTION
## Summary
Adds ValidationStatus.NOT_RUN so Helm.validate when OFF or Phase 2 disabled does not return isValid() true.

## Problem
Empty ValidationReport with no findings reported a valid plan.

## Solution
ValidationReport.notRun() and isValid() true only when status is VALID.

## Tests
SkippedValidationTest (4 cases). gradlew check passed locally.

## Safety
No hardware authority. AuthorityGate unchanged.

## Related issue
Closes #19
Part of #8


Made with [Cursor](https://cursor.com)