### PR TITLE
Reject future-dated world snapshots as stale (closes #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PlanValidator` applies `maxTreeNodes` / `maxTreeDepth` and parallel exclusive-resource checks to reachable expanded subtrees. Unreachable named subtrees remain warnings and are not counted toward live limits (SNAPSHOT stricter validation).
 - Skipped validation reports `NOT_RUN` status; `ValidationReport.isValid()` is false unless validation actually ran and found no errors. Empty skipped reports are no longer treated as valid (SNAPSHOT behavioral break).
 - `SimulatedTreeWalker` resolves named `IntentTree.subtrees()` with a cyclic-reference guard. Missing or cyclic subtrees are `UNAVAILABLE`, never success. Desktop simulation only; still no hardware adapters.
+- Future-dated world snapshots (`timestampNanos` after `HelmClock`) are not fresh and fail eligibility with `STALE_INPUT`. There is no clock-skew budget (SNAPSHOT stricter validation).

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,6 +1,6 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `fdd8920` after [#32](https://github.com/The-Allsparks/HELM/pull/32).
+Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `a475ce3` after [#33](https://github.com/The-Allsparks/HELM/pull/33).
 
 **Identity:** TA-C-GHill. **Max active subagents:** 1.
 
@@ -8,29 +8,20 @@ Maintained by the repository orchestrator. Source: [initial deep audit](audits/i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#20](https://github.com/The-Allsparks/HELM/issues/20) walker named subtrees |
-| Branch | `fix/issue-20-walker-named-subtrees` |
+| Selected issue | [#24](https://github.com/The-Allsparks/HELM/issues/24) future-dated snapshots |
+| Branch | `fix/issue-24-future-snapshots-not-fresh` |
 | Status | Implementation |
 
 ## Ledger (abbreviated)
 
 | Issue | Status | PR |
 |-------|--------|-----|
-| #17 | Closed | [#27](https://github.com/The-Allsparks/HELM/pull/27) merged |
-| #18 | Closed | [#31](https://github.com/The-Allsparks/HELM/pull/31) merged |
-| #19 | Closed | [#32](https://github.com/The-Allsparks/HELM/pull/32) merged |
-| #20 | In progress | pending |
-| #6 #7 | Closed | via #27 |
-| #8 epic | Open | #17–#19 done; #20 closes desktop parity |
+| #17–#20, #6–#8 | Closed | #27, #31, #32, #33 |
+| #24 | In progress | pending |
+| #23 | Ready | README completion |
 | #21 | Blocked | human branch protection |
 | #22 | Ready | do not merge Dependabot #4, #28–#30 |
 | #9–#15 | Blocked | readiness gates |
-
-## Next after #20
-
-1. [#23](https://github.com/The-Allsparks/HELM/issues/23) README completion (small docs)
-2. [#24](https://github.com/The-Allsparks/HELM/issues/24) future-dated snapshots
-3. [#22](https://github.com/The-Allsparks/HELM/issues/22) Dependabot analysis (process, not a library change)
 
 ## Required human decisions
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@
 |---------|--------------|------------|
 | `evaluate` always ineligible | Mode is `OFF` | Expected default. Use `VALIDATE` in desktop tests only |
 | `UNKNOWN_CONDITION` | Fact missing from snapshot | Put the named condition in the snapshot; do not default it to false |
-| `STALE_INPUT` | Snapshot older than max age, or timestamps misaligned | Check clocks and alignment window |
+| `STALE_INPUT` | Snapshot older than max age, future-dated vs `HelmClock`, or timestamps misaligned | Use one clock; do not set snapshot time in the future; check alignment window |
 | `CAPABILITY_UNKNOWN` | BEACON/MIMIC did not report the capability | Leave the task blocked; do not invent AVAILABLE |
 | `validate` returns not run / `isValid()` false with empty findings | Phase 2 flag off or mode OFF | Enable `HelmFeatureFlags.validate()` and set mode to `VALIDATE`; check `ValidationReport.status()` |
 | Tree invalid despite a `ParkSafely` name | Name is not a safety proof | Mark `IntentNode.safeTerminal(...)` and put it last on a root fallback/recovery (typically inside `IntentNode.timeout(...)`). Each ACTION still needs its own timeout. |

--- a/docs/world-snapshot.md
+++ b/docs/world-snapshot.md
@@ -21,7 +21,13 @@ Unrelated timestamps are not combined without checking age and spread. If source
 
 ## Freshness
 
-`HelmConfig.snapshotMaxAge` (default 100 ms) compares snapshot time to `HelmClock`. Stale snapshots fail eligibility with `STALE_INPUT`.
+`HelmConfig.snapshotMaxAge` (default 100 ms) compares snapshot time to `HelmClock`. A snapshot is fresh only when its timestamp is **not after** the clock and its age is within the max age:
+
+```text
+0 <= (nowNanos - timestampNanos) <= snapshotMaxAge
+```
+
+A future-dated snapshot (`timestampNanos > nowNanos`) is **not** treated as fresh. Stale or future snapshots fail eligibility with `STALE_INPUT`. There is no skew budget in this scaffold.
 
 ## Mutation
 

--- a/src/main/java/org/allsparks/helm/snapshot/WorldSnapshot.java
+++ b/src/main/java/org/allsparks/helm/snapshot/WorldSnapshot.java
@@ -201,6 +201,12 @@ public final class WorldSnapshot {
     }
 
     public boolean isFresh(long nowNanos, long maxAgeNanos) {
+        if (maxAgeNanos < 0L) {
+            return false;
+        }
+        if (timestampNanos > nowNanos) {
+            return false;
+        }
         return nowNanos - timestampNanos <= maxAgeNanos;
     }
 

--- a/src/test/java/org/allsparks/helm/HelmEligibilityTest.java
+++ b/src/test/java/org/allsparks/helm/HelmEligibilityTest.java
@@ -160,6 +160,17 @@ class HelmEligibilityTest {
     }
 
     @Test
+    void futureDatedSnapshotIsNotFresh() {
+        WorldSnapshot snapshot = readySnapshot().toBuilder()
+                .timestampNanos(Duration.ofSeconds(1).toNanos())
+                .build();
+        assertFalse(snapshot.isFresh(clock.nanoTime(), Duration.ofMillis(100).toNanos()));
+        TaskEvaluation evaluation = Helm.create(HelmConfig.forTests(clock)).evaluate(sampleTask(), snapshot);
+        assertFalse(evaluation.isEligible());
+        assertTrue(evaluation.rejectionReasons().contains(FailureReason.STALE_INPUT));
+    }
+
+    @Test
     void remainingTimeUnknownIsNotInfinite() {
         Task task = Task.builder("ScorePreload")
                 .requires(Capability.DRIVE_TRANSLATION)

--- a/src/test/java/org/allsparks/helm/snapshot/WorldSnapshotImmutabilityTest.java
+++ b/src/test/java/org/allsparks/helm/snapshot/WorldSnapshotImmutabilityTest.java
@@ -1,6 +1,7 @@
 package org.allsparks.helm.snapshot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,5 +34,8 @@ class WorldSnapshotImmutabilityTest {
         assertNotSame(snapshot, copy);
         assertEquals("copy", copy.snapshotId());
         assertTrue(snapshot.isFresh(10L, 1_000_000L));
+        assertTrue(snapshot.isFresh(10L + 1_000_000L, 1_000_000L));
+        assertFalse(snapshot.isFresh(10L + 1_000_001L, 1_000_000L));
+        assertFalse(snapshot.isFresh(9L, 1_000_000L));
     }
 }


### PR DESCRIPTION
## Summary

World snapshots dated after `HelmClock` are no longer treated as fresh. Eligibility fails with `STALE_INPUT`.

## Problem

`isFresh` used `now - timestamp <= maxAge`. A future timestamp produced a negative age and passed the check.

## Solution

Fail-closed: a snapshot is fresh only when `timestampNanos <= nowNanos` and age is within `snapshotMaxAge`. No skew budget.

## Scope

- `WorldSnapshot.isFresh`
- Eligibility test with a future-dated snapshot
- Direct freshness assertions
- Docs

## Out of scope

- NTP / Android clock policy
- Changing the 100 ms default max age
- Hardware

## Phase / maturity impact

- [ ] Documentation only
- [x] Phase 0 vocabulary
- [ ] Phase 1 passive observation
- [ ] Phase 2 offline validation
- [ ] Phase 3+ (requires explicit safety review and is not approved)
- [ ] Research / citations

## Architecture impact

None beyond the freshness invariant.

## Safety impact

- [x] Does **not** enable hardware command or execute authority by default
- [x] Unknown/stale sensing fails safe
- [x] Replay cannot produce physical output
- [x] No secrets or private team data included
- Future-dated data cannot bypass stale-input rejection.

## Compatibility impact

0.1.0-SNAPSHOT stricter validation.

## Tests

- [x] `./gradlew.bat check` passed locally
- [x] Unit tests added/updated
- [x] Hardware validation status: none

## Validation results

Command: `.\gradlew.bat check --no-daemon`

Result: BUILD SUCCESSFUL

Failure reason: none

Whether failure is introduced by this change: no

## Hardware validation

None.

## Documentation

`docs/world-snapshot.md`, `docs/troubleshooting.md`, `CHANGELOG.md`

## Risks

Low. Intended fail-closed.

## Rollback or disable strategy

Revert this PR.

## Known limitations

No clock-skew budget. Callers must use one `HelmClock`.

## Related issue

Closes #24
