### PR TITLE
Include completion condition in README student API (closes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skipped validation reports `NOT_RUN` status; `ValidationReport.isValid()` is false unless validation actually ran and found no errors. Empty skipped reports are no longer treated as valid (SNAPSHOT behavioral break).
 - `SimulatedTreeWalker` resolves named `IntentTree.subtrees()` with a cyclic-reference guard. Missing or cyclic subtrees are `UNAVAILABLE`, never success. Desktop simulation only; still no hardware adapters.
 - Future-dated world snapshots (`timestampNanos` after `HelmClock`) are not fresh and fail eligibility with `STALE_INPUT`. There is no clock-skew budget (SNAPSHOT stricter validation).
+
+### Changed
+
+- README Phase 0 student snippet includes a completion condition so it matches `PlanValidator`.

--- a/README.md
+++ b/README.md
@@ -110,12 +110,15 @@ Task scoreTask = Task.builder("ScorePreload")
     .requires(Capability.LOW_SCORING)
     .timeout(Duration.ofSeconds(6))
     .fallback("ParkSafely")
+    .completion(Condition.snapshotFact("preloadScored"))
     .build();
 
 TaskEvaluation evaluation = helm.evaluate(scoreTask, worldSnapshot);
 telemetry.addData("Eligible", evaluation.isEligible());
 telemetry.addData("Reason", evaluation.explanation());
 ```
+
+Phase 2 validation also requires a timeout, a fallback name, and a completion condition. Eligibility can pass without the completion condition; `Helm.validate` will not.
 
 HELM remains `OFF` unless the robot application sets a mode. Installing this library does nothing by itself.
 

--- a/docs/goals-and-tasks.md
+++ b/docs/goals-and-tasks.md
@@ -8,7 +8,7 @@ A **task** is a named action that may advance a goal. Tasks declare:
 - whether degraded capabilities are acceptable
 - required logical resources
 - per-dimension confidence requirements
-- preconditions, completion conditions, failure conditions
+- preconditions, completion conditions (required for Phase 2 validity), failure conditions
 - timeout (required for Phase 2 validity)
 - bounded retry policy
 - fallback task name (required for Phase 2 validity)

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,6 +1,6 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `a475ce3` after [#33](https://github.com/The-Allsparks/HELM/pull/33).
+Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `b3b97e0` after [#34](https://github.com/The-Allsparks/HELM/pull/34).
 
 **Identity:** TA-C-GHill. **Max active subagents:** 1.
 
@@ -8,20 +8,21 @@ Maintained by the repository orchestrator. Source: [initial deep audit](audits/i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#24](https://github.com/The-Allsparks/HELM/issues/24) future-dated snapshots |
-| Branch | `fix/issue-24-future-snapshots-not-fresh` |
+| Selected issue | [#23](https://github.com/The-Allsparks/HELM/issues/23) README completion |
+| Branch | `fix/issue-23-readme-completion` |
 | Status | Implementation |
 
 ## Ledger (abbreviated)
 
-| Issue | Status | PR |
-|-------|--------|-----|
-| #17–#20, #6–#8 | Closed | #27, #31, #32, #33 |
-| #24 | In progress | pending |
-| #23 | Ready | README completion |
-| #21 | Blocked | human branch protection |
-| #22 | Ready | do not merge Dependabot #4, #28–#30 |
-| #9–#15 | Blocked | readiness gates |
+| Issue | Status |
+|-------|--------|
+| #17–#20, #24, #6–#8 | Closed |
+| #23 | In progress |
+| #21 | Blocked — branch protection |
+| #22 | Ready — Dependabot analysis; do not merge #4, #28–#30 |
+| #25 | Ready — desktop characterization, no Control Hub claims |
+| #26 | Ready — CI-compiled example path |
+| #9–#15 | Blocked — readiness gates |
 
 ## Required human decisions
 


### PR DESCRIPTION
## Summary

README Phase 0 student snippet now includes a completion condition so it matches PlanValidator.

## Problem

The quick start omitted completion. Eligibility can pass; validation fails.

## Solution

Add `.completion(Condition.snapshotFact(preloadScored))` and note that Phase 2 validation requires timeout, fallback, and completion.

## Scope

README, goals-and-tasks.md, changelog. Validator unchanged.

## Out of scope

Example Gradle module (#26). Weakening validation.

## Phase / maturity impact

- [x] Documentation only

## Safety impact

- [x] Does **not** enable hardware command or execute authority by default
- [x] No secrets or private team data included

## Tests

- [x] `./gradlew.bat check` passed locally
- [x] Hardware validation status: none

## Related issue

Closes #23

Made with [Cursor](https://cursor.com)