### PR TITLE
Add CI-compiled Phase 0 desktop example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Compilable Phase 0 desktop example at `src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java` (CI `check`; not an OpMode).
 - Phase 0 vocabulary: goals, tasks, conditions, capabilities, resources, outcomes, and intent-tree structure.
 - Phase 1 passive observation of stated intent and outcomes.
 - Phase 2 offline/static plan validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ cd HELM
 .\gradlew.bat test
 ```
 
+The CI-compiled Phase 0 student example is `src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java`. See [examples/README.md](examples/README.md).
+
 ## Rules of engagement
 
 1. **Do not enable robot execution** in pull requests. Phase 3+ requires an explicit approval gate.

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,6 +1,6 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `5093fd2` after [#35](https://github.com/The-Allsparks/HELM/pull/35).
+Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `b7a455a` after [#36](https://github.com/The-Allsparks/HELM/pull/36).
 
 **Identity:** TA-C-GHill. **Max active subagents:** 1.
 
@@ -8,20 +8,18 @@ Maintained by the repository orchestrator. Source: [initial deep audit](audits/i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#22](https://github.com/The-Allsparks/HELM/issues/22) Dependabot policy |
-| Branch | `fix/issue-22-dependabot-policy` |
+| Selected issue | [#26](https://github.com/The-Allsparks/HELM/issues/26) CI-compiled example |
+| Branch | `fix/issue-26-compilable-example` |
 | Status | Implementation |
 
 ## Ledger (abbreviated)
 
 | Issue | Status |
 |-------|--------|
-| #17–#20, #24, #6–#8 | Closed |
-| #23 | Closed via [#35](https://github.com/The-Allsparks/HELM/pull/35) |
+| #17–#20, #22–#24, #6–#8 | Closed |
 | #21 | Blocked — branch protection |
-| #22 | In progress — close Gradle 9 / JUnit 6; wait on Actions majors |
 | #25 | Ready — desktop characterization, no Control Hub claims |
-| #26 | Ready — CI-compiled example path |
+| #26 | In progress — CI-compiled example path |
 | #9–#15 | Blocked — readiness gates |
 
 ## Required human decisions

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,40 +2,27 @@
 
 These sketches show the Phase 0–2 student API. They are **not** robot OpModes and they do **not** command hardware.
 
-See unit tests:
+## Compilable path (CI)
+
+Open and run this test class. `./gradlew check` compiles and executes it on Ubuntu and Windows:
+
+- [`src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java`](../src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java)
+
+```powershell
+.\gradlew.bat test --tests org.allsparks.helm.examples.Phase0DescribeExampleTest
+```
+
+On Linux/macOS:
+
+```bash
+./gradlew test --tests org.allsparks.helm.examples.Phase0DescribeExampleTest
+```
+
+That file is the source of truth for the student API sketch (goal, task with completion, intent tree with timed actions and an explicit `safeTerminal`, desktop evaluation, and validation). Phase 2 rejects ACTION nodes that have no timeout. Do not copy a second sketch here — it will drift.
+
+Related tests (behavior, not the student example):
 
 - `org.allsparks.helm.HelmEligibilityTest#studentApiExampleCompilesAndEvaluates`
 - `org.allsparks.helm.intent.IntentTreeBehaviorTest`
 
-```java
-Goal scorePreload = Goal.named("ScorePreload");
-
-Task scoreTask = Task.builder("ScorePreload")
-    .requires(Capability.DRIVE_TRANSLATION)
-    .requires(Capability.LOW_SCORING)
-    .timeout(Duration.ofSeconds(6))
-    .fallback("ParkSafely")
-    .completion(Condition.snapshotFact("preloadScored"))
-    .build();
-
-IntentTree autonomous = IntentTree.named("SimpleAutonomous")
-    .fallback(
-        IntentTree.sequence(
-            IntentTree.condition("PreflightReady"),
-            IntentTree.action("ScorePreload"),
-            IntentTree.action("AcquireNearestPiece")
-        ),
-        IntentNode.timeout(
-            "parkTimeout",
-            Duration.ofSeconds(3),
-            IntentNode.builder("ParkSafely", IntentNodeKind.ACTION)
-                .safeTerminal(true)
-                .timeout(TimeoutPolicy.ofSeconds(3))
-                .build())
-    );
-
-TaskEvaluation evaluation = helm.evaluate(scoreTask, worldSnapshot);
-DecisionRecord recommendation = helm.recommend(List.of(scoreTask), worldSnapshot);
-```
-
-`recommendation` explains that shadow selection is not enabled. Default `Helm.create()` is mode `OFF`.
+Default `Helm.create()` is mode `OFF` and `allowsPhysicalOutput()` is always false in this scaffold.

--- a/src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java
+++ b/src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java
@@ -1,0 +1,145 @@
+package org.allsparks.helm.examples;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.allsparks.helm.Helm;
+import org.allsparks.helm.HelmConfig;
+import org.allsparks.helm.HelmFeatureFlags;
+import org.allsparks.helm.HelmMode;
+import org.allsparks.helm.capability.Capability;
+import org.allsparks.helm.capability.CapabilityAvailability;
+import org.allsparks.helm.clock.ManualClock;
+import org.allsparks.helm.condition.Condition;
+import org.allsparks.helm.condition.ConditionResult;
+import org.allsparks.helm.condition.ConditionValue;
+import org.allsparks.helm.confidence.Confidence;
+import org.allsparks.helm.confidence.ConfidenceDimension;
+import org.allsparks.helm.decision.DecisionRecord;
+import org.allsparks.helm.goal.Goal;
+import org.allsparks.helm.intent.IntentNode;
+import org.allsparks.helm.intent.IntentNodeKind;
+import org.allsparks.helm.intent.IntentTree;
+import org.allsparks.helm.snapshot.HeldGamePiece;
+import org.allsparks.helm.snapshot.PoseEstimate;
+import org.allsparks.helm.snapshot.RemainingTime;
+import org.allsparks.helm.snapshot.WorldSnapshot;
+import org.allsparks.helm.task.Task;
+import org.allsparks.helm.task.TaskEvaluation;
+import org.allsparks.helm.task.TimeoutPolicy;
+import org.allsparks.helm.validate.ValidationReport;
+import org.allsparks.helm.validate.ValidationStatus;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Compilable Phase 0–2 desktop example. Not an OpMode. Never commands hardware.
+ *
+ * <p>Run: {@code ./gradlew test --tests org.allsparks.helm.examples.Phase0DescribeExampleTest}
+ */
+class Phase0DescribeExampleTest {
+    private final ManualClock clock = new ManualClock();
+
+    @Test
+    void defaultInstallDoesNothingAndCannotCommandHardware() {
+        Helm helm = Helm.create();
+        assertEquals(HelmMode.OFF, helm.mode());
+        assertFalse(helm.allowsPhysicalOutput());
+    }
+
+    @Test
+    void describeTaskAndTreeThenEvaluateOnDesktop() {
+        Goal scorePreload = Goal.named("ScorePreload");
+
+        Task scoreTask = Task.builder("ScorePreload")
+                .goal(scorePreload)
+                .requires(Capability.DRIVE_TRANSLATION)
+                .requires(Capability.LOW_SCORING)
+                .timeout(Duration.ofSeconds(6))
+                .fallback("ParkSafely")
+                .completion(Condition.snapshotFact("preloadScored"))
+                .precondition(Condition.snapshotFact("PreflightReady"))
+                .build();
+
+        IntentTree autonomous = IntentTree.named("SimpleAutonomous")
+                .fallback(
+                        IntentTree.sequence(
+                                IntentTree.condition("PreflightReady"),
+                                timedAction("ScorePreload"),
+                                timedAction("AcquireNearestPiece")),
+                        IntentNode.timeout(
+                                "parkTimeout",
+                                Duration.ofSeconds(3),
+                                timedSafeTerminal("ParkSafely")));
+
+        Helm helm = Helm.create(HelmConfig.builder()
+                .mode(HelmMode.VALIDATE)
+                .flags(HelmFeatureFlags.validate())
+                .clock(clock)
+                .build());
+
+        assertFalse(helm.allowsPhysicalOutput());
+
+        TaskEvaluation evaluation = helm.evaluate(scoreTask, desktopSnapshot());
+        assertTrue(evaluation.isEligible());
+
+        ValidationReport taskReport = helm.validate(scoreTask);
+        assertEquals(ValidationStatus.VALID, taskReport.status());
+        assertTrue(taskReport.isValid());
+
+        ValidationReport treeReport = helm.validate(autonomous);
+        assertEquals(ValidationStatus.VALID, treeReport.status());
+        assertTrue(treeReport.isValid());
+
+        DecisionRecord recommendation = helm.recommend(List.of(scoreTask), desktopSnapshot());
+        assertFalse(recommendation.authoritative());
+        assertEquals("SimpleAutonomous", autonomous.name());
+    }
+
+    /** Phase 2 rejects ACTION nodes that have no timeout. */
+    private static IntentNode timedAction(String name) {
+        return IntentNode.builder(name, IntentNodeKind.ACTION)
+                .timeout(TimeoutPolicy.ofSeconds(3))
+                .build();
+    }
+
+    private static IntentNode timedSafeTerminal(String name) {
+        return IntentNode.builder(name, IntentNodeKind.ACTION)
+                .safeTerminal(true)
+                .timeout(TimeoutPolicy.ofSeconds(3))
+                .build();
+    }
+
+    /**
+     * Snapshots are built by the application (or a test). HELM does not sense the field.
+     */
+    private WorldSnapshot desktopSnapshot() {
+        return WorldSnapshot.builder()
+                .snapshotId("desktop-example")
+                .timestampNanos(0L)
+                .pose(PoseEstimate.builder()
+                        .xInches(12)
+                        .yInches(36)
+                        .headingRadians(0)
+                        .timestampNanos(0L)
+                        .positionConfidence(Confidence.of(0.9d))
+                        .headingConfidence(Confidence.of(0.9d))
+                        .provider("desktop")
+                        .build())
+                .heldGamePiece(HeldGamePiece.empty(Confidence.of(0.8d), 0L))
+                .capability(Capability.DRIVE_TRANSLATION, CapabilityAvailability.AVAILABLE, "beacon")
+                .capability(Capability.LOW_SCORING, CapabilityAvailability.AVAILABLE, "mimic")
+                .condition(ConditionResult.builder("PreflightReady")
+                        .value(ConditionValue.TRUE)
+                        .source("app")
+                        .timestampNanos(0L)
+                        .explanation("Preflight checks passed")
+                        .build())
+                .confidence(ConfidenceDimension.POSITION, Confidence.of(0.9d))
+                .remainingAutonomous(RemainingTime.of(Duration.ofSeconds(25)))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java` as the student-facing, CI-compiled Phase 0–2 example (not an OpMode; physical output stays refused).
- Points `examples/README.md` and CONTRIBUTING at that file so mentors open a real source path instead of a sketch that can drift.

Closes #26.

## Phase / maturity impact

- [x] Documentation only
- [x] Phase 0 vocabulary
- [ ] Phase 1 passive observation
- [x] Phase 2 offline validation
- [ ] Phase 3+ (requires explicit safety review and is not approved)
- [ ] Research / citations

## Safety

- [x] Does **not** enable hardware command or execute authority by default
- [x] Unknown/stale sensing fails safe
- [x] Replay cannot produce physical output
- [x] No secrets or private team data included

## Validation evidence

- [x] `.\gradlew.bat test --tests org.allsparks.helm.examples.Phase0DescribeExampleTest` passed locally
- [x] Unit tests added/updated
- [x] Hardware validation status: none

## Checklist

- [x] Docs updated if behavior or maturity labels changed
- [x] Citations distinguish verified fact vs inference vs hypothesis
- [x] Linked related issues / milestones
- [x] Does not claim unperformed hardware validation

Made with [Cursor](https://cursor.com)