### PR TITLE
Record desktop decision-time characterization without Control Hub claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Compilable Phase 0 desktop example at `src/test/java/org/allsparks/helm/examples/Phase0DescribeExampleTest.java` (CI `check`; not an OpMode).
+- Desktop performance characterization: `ManualClock` records `evaluationNanos == 0`; the 5 ms budget is a clock-delta policy, not a Control Hub measurement.
 - Phase 0 vocabulary: goals, tasks, conditions, capabilities, resources, outcomes, and intent-tree structure.
 - Phase 1 passive observation of stated intent and outcomes.
 - Phase 2 offline/static plan validation.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -24,3 +24,17 @@ Rules:
 Worst-case evaluation cost is linear in required capabilities, confidence dimensions, preconditions, and resource checks for a single task. Desktop unit tests measure completeness under a jumping clock; they are **not** Control Hub timings.
 
 **Hardware performance measurements: none.** Do not claim Control Hub budgets are proven.
+
+## Desktop characterization (2026-08-17)
+
+Verified fact from unit tests on a development JVM. **Not** Control Hub, **not** FTC Android, **not** a 5 ms proof.
+
+| Observation | Evidence | What it is not |
+|-------------|----------|----------------|
+| `TaskEvaluation.evaluationNanos()` is `0` when `ManualClock` does not advance | `DesktopPerformanceCharacterizationTest` | Not “evaluation is free” or “under 5 ms on the robot” |
+| If the configured clock delta exceeds `decisionTimeBudget` (5 ms), evaluation is **incomplete** and `TIME_BUDGET_EXCEEDED` | `DeterminismAndReplayTest.exceedingDecisionBudgetMarksEvaluationIncomplete` | Not a wall-clock benchmark; CI does not assert real elapsed time |
+| Allocation / GC pressure | Not measured | Do not start “make it faster” work from this table |
+
+The 5 ms figure in the budget table is a **fail-closed policy** (`HelmClock` delta after a full evaluation). It is not a measured latency. Do not relax incompleteness to make numbers look better.
+
+Control Hub characterization remains blocked until a dated run records device, firmware, SDK, operator, and date.

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,6 +1,6 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `b7a455a` after [#36](https://github.com/The-Allsparks/HELM/pull/36).
+Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `66ca362` after [#39](https://github.com/The-Allsparks/HELM/pull/39).
 
 **Identity:** TA-C-GHill. **Max active subagents:** 1.
 
@@ -8,18 +8,17 @@ Maintained by the repository orchestrator. Source: [initial deep audit](audits/i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#26](https://github.com/The-Allsparks/HELM/issues/26) CI-compiled example |
-| Branch | `fix/issue-26-compilable-example` |
+| Selected issue | [#25](https://github.com/The-Allsparks/HELM/issues/25) desktop characterization |
+| Branch | `fix/issue-25-desktop-characterization` |
 | Status | Implementation |
 
 ## Ledger (abbreviated)
 
 | Issue | Status |
 |-------|--------|
-| #17–#20, #22–#24, #6–#8 | Closed |
+| #17–#20, #22–#24, #26, #6–#8 | Closed |
 | #21 | Blocked — branch protection |
-| #25 | Ready — desktop characterization, no Control Hub claims |
-| #26 | In progress — CI-compiled example path |
+| #25 | In progress — desktop characterization, no Control Hub claims |
 | #9–#15 | Blocked — readiness gates |
 
 ## Required human decisions

--- a/src/test/java/org/allsparks/helm/task/DesktopPerformanceCharacterizationTest.java
+++ b/src/test/java/org/allsparks/helm/task/DesktopPerformanceCharacterizationTest.java
@@ -1,0 +1,63 @@
+package org.allsparks.helm.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.allsparks.helm.Helm;
+import org.allsparks.helm.HelmConfig;
+import org.allsparks.helm.HelmFeatureFlags;
+import org.allsparks.helm.HelmMode;
+import org.allsparks.helm.clock.ManualClock;
+import org.allsparks.helm.condition.Condition;
+import org.allsparks.helm.outcome.FailureReason;
+import org.allsparks.helm.snapshot.WorldSnapshot;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Desktop characterization of decision-time accounting. This is not a Control Hub
+ * benchmark and must not be cited as hardware proof.
+ *
+ * <p>{@link ManualClock} does not advance unless the test moves it, so
+ * {@link TaskEvaluation#evaluationNanos()} is zero on the happy path. The 5 ms
+ * budget is a policy enforced against the configured {@code HelmClock}, not a
+ * measured device latency. Wall-clock assertions are intentionally absent so CI
+ * is not flaky.
+ *
+ * @see org.allsparks.helm.replay.DeterminismAndReplayTest#exceedingDecisionBudgetMarksEvaluationIncomplete()
+ */
+class DesktopPerformanceCharacterizationTest {
+    @Test
+    void manualClockRecordsZeroEvaluationNanosWithoutProvingDeviceLatency() {
+        ManualClock clock = new ManualClock();
+        Helm helm = Helm.create(HelmConfig.builder()
+                .mode(HelmMode.VALIDATE)
+                .flags(HelmFeatureFlags.validate())
+                .clock(clock)
+                .decisionTimeBudget(Duration.ofMillis(5))
+                .snapshotMaxAge(Duration.ofSeconds(1))
+                .build());
+        TaskEvaluation evaluation = helm.evaluate(sampleTask(), desktopSnapshot());
+        assertEquals(0L, evaluation.evaluationNanos(),
+                "ManualClock is frozen; zero evaluationNanos is not a 5 ms Control Hub measurement");
+        assertTrue(evaluation.isComplete());
+        assertFalse(evaluation.rejectionReasons().contains(FailureReason.TIME_BUDGET_EXCEEDED));
+    }
+
+    private static Task sampleTask() {
+        return Task.builder("ScorePreload")
+                .timeout(Duration.ofSeconds(1))
+                .fallback("ParkSafely")
+                .completion(Condition.snapshotFact("done"))
+                .build();
+    }
+
+    private static WorldSnapshot desktopSnapshot() {
+        return WorldSnapshot.builder()
+                .snapshotId("desktop-perf")
+                .timestampNanos(0L)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

- Documents that the 5 ms decision budget is a `HelmClock` fail-closed **policy**, not a measured Control Hub latency.
- Adds `DesktopPerformanceCharacterizationTest`: frozen `ManualClock` records `evaluationNanos == 0`. Wall-clock assertions stay out of CI.
- Points at the existing jumping-clock incomplete path in `DeterminismAndReplayTest`.

Closes #25.

## Phase / maturity impact

- [x] Documentation only
- [ ] Phase 0 vocabulary
- [ ] Phase 1 passive observation
- [ ] Phase 2 offline validation
- [ ] Phase 3+ (requires explicit safety review and is not approved)
- [x] Research / citations

## Safety

- [x] Does **not** enable hardware command or execute authority by default
- [x] Unknown/stale sensing fails safe
- [x] Replay cannot produce physical output
- [x] No secrets or private team data included

## Validation evidence

- [x] `.\gradlew.bat test --tests org.allsparks.helm.task.DesktopPerformanceCharacterizationTest` passed locally
- [x] Unit tests added/updated
- [x] Hardware validation status: none

## Checklist

- [x] Docs updated if behavior or maturity labels changed
- [x] Citations distinguish verified fact vs inference vs hypothesis
- [x] Linked related issues / milestones
- [x] Does not claim unperformed hardware validation

Made with [Cursor](https://cursor.com)