### PR TITLE
SHA-pin GitHub Actions checkout and setup-java v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Stay on SHA-pinned v4 until a reviewed major (see docs/conventions.md and #41).
+      - dependency-name: "actions/checkout"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "actions/setup-java"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: gradle
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: "17"
@@ -29,7 +29,7 @@ jobs:
   docs-structure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Required documentation present
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - README Phase 0 student snippet includes a completion condition so it matches `PlanValidator`.
-- Dependabot ignores Gradle wrapper and JUnit BOM **major** upgrades so they stay on the Allsparks Gradle 8.7 / JUnit 5 convention. GitHub Actions major bumps remain open for SHA-pin follow-up, not merge.
+- Dependabot ignores Gradle wrapper and JUnit BOM **major** upgrades so they stay on the Allsparks Gradle 8.7 / JUnit 5 convention.
+- CI pins `actions/checkout` v4.4.0 and `actions/setup-java` v4.9.1 by full commit SHA. Action major bumps are ignored.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -33,7 +33,8 @@ Recorded 2026-08-17 against issue [#22](https://github.com/The-Allsparks/HELM/is
 
 - **Gradle wrapper 8.7 → 9.x:** close. Gradle 9 is a major with breaking defaults; AMPER/MIMIC remain on 8.7. Java 11 source is unchanged, but a HELM-only Gradle 9 jump desyncs student setup from the rest of the org. Revisit only with a dated org-wide toolchain RFC.
 - **JUnit BOM 5.10.x → 6.x:** close. Test-only, so FTC Android runtime is unaffected, but JUnit 6 is not the Allsparks test convention. Accept 5.x patch/minor when offered.
-- **`actions/checkout` v4 → v7 and `actions/setup-java` v4 → v5:** wait. Do not merge floating major tags. A later PR may SHA-pin the current v4 line with version comments (F-DEP-002). Jumping majors without pins does not fix the supply-chain issue.
+- **`actions/checkout` v4 → v7 and `actions/setup-java` v4 → v5:** do not merge floating major tags. CI pins full commit SHAs of the v4 line (`checkout` v4.4.0, `setup-java` v4.9.1) with version comments (F-DEP-002, #41). `setup-java` v4.9.1 is the last v4 release and is deprecated; a SHA-pinned v5 bump is a later reviewed PR.
+- Dependabot majors for those two Actions are ignored. Minor/patch SHA updates within v4 remain allowed.
 - Do not combine a major bump with feature work.
 
 ## Intentional HELM deviations

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,6 +1,6 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `66ca362` after [#39](https://github.com/The-Allsparks/HELM/pull/39).
+Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `bbcce52` after [#40](https://github.com/The-Allsparks/HELM/pull/40).
 
 **Identity:** TA-C-GHill. **Max active subagents:** 1.
 
@@ -8,21 +8,24 @@ Maintained by the repository orchestrator. Source: [initial deep audit](audits/i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#25](https://github.com/The-Allsparks/HELM/issues/25) desktop characterization |
-| Branch | `fix/issue-25-desktop-characterization` |
+| Selected issue | [#41](https://github.com/The-Allsparks/HELM/issues/41) SHA-pin Actions v4 |
+| Branch | `fix/issue-41-sha-pin-actions` |
 | Status | Implementation |
 
 ## Ledger (abbreviated)
 
 | Issue | Status |
 |-------|--------|
-| #17–#20, #22–#24, #26, #6–#8 | Closed |
+| #17–#20, #22–#26, #6–#8 | Closed |
 | #21 | Blocked — branch protection |
-| #25 | In progress — desktop characterization, no Control Hub claims |
+| #41 | In progress — SHA-pin checkout and setup-java v4 |
 | #9–#15 | Blocked — readiness gates |
+| #4, #28 | Close after #41; superseded by SHA pins |
+| #37, #38 | Wait — Gradle 8.7 pin / JUnit 5.14 CI red |
 
 ## Required human decisions
 
 - Enable branch protection (#21)
-- SHA-pin GitHub Actions v4 line (follow-up from #22; PRs #4 and #28 wait)
 - FTC SDK compile job (audit F-TEST-004; not filed)
+- Org-wide Gradle 8.x bump before merging #37
+- Dedicated JUnit 5.14 restore-CI PR before merging #38


### PR DESCRIPTION
## Summary

- Pins `actions/checkout` to `11d5960a326750d5838078e36cf38b85af677262` (v4.4.0) and `actions/setup-java` to `cf277c60eb25467037889841efdb72551f06f6c3` (v4.9.1) with version comments.
- Ignores Dependabot **major** updates for those two Actions so floating #4/#28 do not return.
- Notes that setup-java v4.9.1 is the last v4 and is deprecated; a SHA-pinned v5 bump is a later reviewed PR.

Closes #41.
Supersedes #4 and #28.

## Phase / maturity impact

- [x] Documentation only
- [ ] Phase 0 vocabulary
- [ ] Phase 1 passive observation
- [ ] Phase 2 offline validation
- [ ] Phase 3+ (requires explicit safety review and is not approved)
- [ ] Research / citations

(CI supply-chain pin; no HELM phase behavior change.)

## Safety

- [x] Does **not** enable hardware command or execute authority by default
- [x] Unknown/stale sensing fails safe
- [x] Replay cannot produce physical output
- [x] No secrets or private team data included

## Validation evidence

- [ ] `./gradlew check` (CI must run on the pinned Actions)
- [ ] Unit tests added/updated
- [x] Hardware validation status: none

## Checklist

- [x] Docs updated if behavior or maturity labels changed
- [x] Citations distinguish verified fact vs inference vs hypothesis
- [x] Linked related issues / milestones
- [x] Does not claim unperformed hardware validation

Made with [Cursor](https://cursor.com)