### PR TITLE
Align JUnit 5.14 with Gradle 8.7 via platform-launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README Phase 0 student snippet includes a completion condition so it matches `PlanValidator`.
 - Dependabot ignores Gradle wrapper and JUnit BOM **major** upgrades so they stay on the Allsparks Gradle 8.7 / JUnit 5 convention.
 - CI pins `actions/checkout` v4.4.0 and `actions/setup-java` v4.9.1 by full commit SHA. Action major bumps are ignored.
+- JUnit BOM 5.14.4 with an explicit `junit-platform-launcher` on the test runtime classpath so Gradle 8.7 does not use its bundled launcher (5.12+ otherwise fails every test).

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,9 @@ repositories {
 }
 
 dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation platform('org.junit:junit-bom:5.14.4')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test', Test) {

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -32,7 +32,7 @@ Inspected 2026-08-17: ViDAR, AMPER, MIMIC, BEACON, TRACE.
 Recorded 2026-08-17 against issue [#22](https://github.com/The-Allsparks/HELM/issues/22).
 
 - **Gradle wrapper 8.7 → 9.x:** close. Gradle 9 is a major with breaking defaults; AMPER/MIMIC remain on 8.7. Java 11 source is unchanged, but a HELM-only Gradle 9 jump desyncs student setup from the rest of the org. Revisit only with a dated org-wide toolchain RFC.
-- **JUnit BOM 5.10.x → 6.x:** close. Test-only, so FTC Android runtime is unaffected, but JUnit 6 is not the Allsparks test convention. Accept 5.x patch/minor when offered.
+- **JUnit BOM 5.10.x → 6.x:** close. Test-only, so FTC Android runtime is unaffected, but JUnit 6 is not the Allsparks test convention. **JUnit 5.14.x is acceptable** on Gradle 8.7 if `testRuntimeOnly 'org.junit.platform:junit-platform-launcher'` is declared so the BOM launcher matches the engine (without it, 5.12+ fails every test via unaligned `junit-platform-launcher`).
 - **`actions/checkout` v4 → v7 and `actions/setup-java` v4 → v5:** do not merge floating major tags. CI pins full commit SHAs of the v4 line (`checkout` v4.4.0, `setup-java` v4.9.1) with version comments (F-DEP-002, #41). `setup-java` v4.9.1 is the last v4 release and is deprecated; a SHA-pinned v5 bump is a later reviewed PR.
 - Dependabot majors for those two Actions are ignored. Minor/patch SHA updates within v4 remain allowed.
 - Do not combine a major bump with feature work.

--- a/docs/priority-ledger.md
+++ b/docs/priority-ledger.md
@@ -1,6 +1,6 @@
 # HELM priority ledger
 
-Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `bbcce52` after [#40](https://github.com/The-Allsparks/HELM/pull/40).
+Maintained by the repository orchestrator. Source: [initial deep audit](audits/initial-deep-audit.md). **`main`:** `1a8d581` after [#42](https://github.com/The-Allsparks/HELM/pull/42).
 
 **Identity:** TA-C-GHill. **Max active subagents:** 1.
 
@@ -8,24 +8,22 @@ Maintained by the repository orchestrator. Source: [initial deep audit](audits/i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#41](https://github.com/The-Allsparks/HELM/issues/41) SHA-pin Actions v4 |
-| Branch | `fix/issue-41-sha-pin-actions` |
+| Selected issue | JUnit 5.14 + Gradle 8.7 launcher alignment (supersedes #38) |
+| Branch | `fix/issue-junit-5-14-compat` |
 | Status | Implementation |
 
 ## Ledger (abbreviated)
 
 | Issue | Status |
 |-------|--------|
-| #17–#20, #22–#26, #6–#8 | Closed |
+| #17–#26, #41, #6–#8 | Closed |
 | #21 | Blocked — branch protection |
-| #41 | In progress — SHA-pin checkout and setup-java v4 |
 | #9–#15 | Blocked — readiness gates |
-| #4, #28 | Close after #41; superseded by SHA pins |
-| #37, #38 | Wait — Gradle 8.7 pin / JUnit 5.14 CI red |
+| #37 | Wait — Gradle 8.7 pin until AMPER/MIMIC move |
+| #38 | In progress — restore CI with `junit-platform-launcher` |
 
 ## Required human decisions
 
 - Enable branch protection (#21)
 - FTC SDK compile job (audit F-TEST-004; not filed)
 - Org-wide Gradle 8.x bump before merging #37
-- Dedicated JUnit 5.14 restore-CI PR before merging #38


### PR DESCRIPTION
## Summary

- Bumps `org.junit:junit-bom` 5.10.2 → **5.14.4** (still JUnit 5; not JUnit 6).
- Adds `testRuntimeOnly 'org.junit.platform:junit-platform-launcher'` so Gradle 8.7 does not use its bundled old launcher. Without this, JUnit 5.12+ fails every test (unaligned engine vs launcher).
- Keeps Gradle **8.7**. Java 11 source/target unchanged.

Supersedes #38.

## Phase / maturity impact

- [x] Documentation only
- [ ] Phase 3+ (requires explicit safety review and is not approved)

(Test toolchain only.)

## Safety

- [x] Does **not** enable hardware command or execute authority by default
- [x] Hardware validation status: none

Made with [Cursor](https://cursor.com)